### PR TITLE
auto-create merchant records for IDs

### DIFF
--- a/src/routes/createButton.ts
+++ b/src/routes/createButton.ts
@@ -25,6 +25,7 @@ import type { Request, Response } from 'express'
 import { body, validationResult } from 'express-validator'
 import { MAX_PAYMENT_SATS } from '../utils/constants'
 import { logWithTimestamp } from '../utils/logging'
+import { ensureMerchantExists } from '../utils/merchant'
 const db: Knex = knex(knexConfig)
 interface RequestBody {
   amount?: number
@@ -104,6 +105,7 @@ export default {
       buttonId
     })
     try {
+      await ensureMerchantExists(db, merchantId)
       // Verify or initialize IDs in ids table
       const initializeId = async (id: string, type: 'payment' | 'button') => {
         const exists = await db('ids').where({ id, type }).first()

--- a/src/routes/initializeIds.ts
+++ b/src/routes/initializeIds.ts
@@ -41,6 +41,7 @@ import { body, validationResult } from 'express-validator'
 import { logWithTimestamp } from '../utils/logging'
 import { generateBase58, getBase58Regex, isBase58, isMerchantId } from '../utils/general'
 import { generateAndValidateUniqueId } from '../utils/idGenerator'
+import { ensureMerchantExists } from '../utils/merchant'
 const db: Knex = knex(knexConfig)
 interface Ids {
   buttonId?: string
@@ -161,6 +162,7 @@ export default {
       })
       return
     }
+    await ensureMerchantExists(db, merchantId)
     logWithTimestamp(F, '✅ [initializeIds] MerchantId validated:', { merchantId })
     let id =
       paymentId ||

--- a/src/routes/invoice.ts
+++ b/src/routes/invoice.ts
@@ -22,6 +22,7 @@ import { body, validationResult } from 'express-validator'
 import { logWithTimestamp } from '../utils/logging'
 import { CONFIG } from '../utils/constants'
 import { generateAndValidateUniqueId } from '../utils/idGenerator'
+import { ensureMerchantExists } from '../utils/merchant'
 const db: Knex = knex(knexConfig)
 
 interface PaymentButton {
@@ -105,6 +106,7 @@ export default {
       description
     })
     try {
+      await ensureMerchantExists(db, merchantId)
       // Verify the payment button exists and belongs to the specified merchant
       logWithTimestamp(F, '🔍 [invoice] [Step 2] Executing query:', { paymentId, merchantId })
       const button: PaymentButton | undefined = await db('payment_buttons')

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -13,6 +13,7 @@ import knex, { Knex } from 'knex'
 import knexConfig from '../../knexfile'
 import { generateBase58 } from './general'
 import { logWithTimestamp } from './logging'
+import { ensureMerchantExists } from './merchant'
 const db: Knex = knex(knexConfig)
 const F = 'utils/idGenerator'
 export async function generateAndValidateUniqueId(
@@ -25,6 +26,7 @@ export async function generateAndValidateUniqueId(
   if (!description || typeof description !== 'string' || description.length > 80) {
     throw new Error('Description is required and must not exceed 80 characters')
   }
+  await ensureMerchantExists(db, merchantId)
   let id = generateBase58(12)
   let attempts = 0
   let finalDescription = description

--- a/src/utils/merchant.ts
+++ b/src/utils/merchant.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex'
+import { logWithTimestamp } from './logging'
+
+const F = 'utils/merchant'
+
+export async function ensureMerchantExists (db: Knex, merchantId: string): Promise<void> {
+  if (!merchantId) return
+  await db('merchants')
+    .insert({
+      merchant_id: merchantId,
+      custom_fee_rate: 0,
+      welcomed: 0,
+      custom_fee: 0,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now()
+    })
+    .onConflict('merchant_id')
+    .ignore()
+  logWithTimestamp(F, '✅ Merchant ensured:', { merchantId })
+}


### PR DESCRIPTION
## Summary
- add `ensureMerchantExists` utility to insert merchant rows if missing
- call the helper across createButton, initializeIds, invoice, and ID generation to avoid FK errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a2becddc832e8f4635d736ad91df